### PR TITLE
Fix race condition in mcp4728

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -24,14 +24,14 @@ class MCP4728Actor(ActorBase):
     e_power_actor = Property.Actor("Power On/Off Actor", description="Actor to use to control power")
     timeout = Property.Number("Notification duration (ms)", True, 1000,
                               description="0ms will disable notifications completely")
-    z_debug = Property.Select("Debug Messages", [False, True], description="Display debug notifications")
+    z_debug = Property.Select("Debug Messages", ["Off", "On"], description="Display debug notifications")
 
     def init(self):
         address = int(self.a_address)
         channel = int(self.b_channel)
 
         self.dac = mcp4728.MCP4728(address)
-        if self.z_debug:
+        if self.z_debug == "On":
             cbpi.notify("Connected to MCP4728",
                         "DAC Address {:d}: DAC Channel {:d}".format(address, channel),
                         timeout=self.timeout)
@@ -71,7 +71,7 @@ class MCP4728Actor(ActorBase):
         else:
             self.dac.set_value(channel, self.value)
 
-        if self.z_debug:
+        if self.z_debug == "On":
             value = self.dac.get_value(channel)
             cbpi.notify("MCP4728 Set Value", "Channel {:d}: Value {:d}".format(channel, value), timeout=self.timeout)
 
@@ -85,7 +85,7 @@ class MCP4728Actor(ActorBase):
             self.dac.set_value(channel, 0)
 
         self.state = 0
-        if self.z_debug:
+        if self.z_debug == "On":
             value = self.dac.get_value(channel)
             cbpi.notify("MCP4728 Current Value", "Channel {:d}: Value {:d}".format(channel, value),
                         timeout=self.timeout)
@@ -103,7 +103,7 @@ class MCP4728Actor(ActorBase):
         else:
             self.dac.set_value(channel, self.value)
 
-        if self.z_debug:
+        if self.z_debug == "On":
             value = self.dac.get_value(channel)
             cbpi.notify("MCP4728 Current Value", "Channel {:d}: Value {:d}".format(channel, value),
                         timeout=self.timeout)

--- a/__init__.py
+++ b/__init__.py
@@ -14,18 +14,17 @@ class MCP4728Actor(ActorBase):
     actor.
     """
     a_address = Property.Select("DAC Address", [0, 1, 2, 3, 4, 5, 6, 7],
-                              description="Minor address of the MCP4728 DAC unit. Use 0 unless you have changed the address manually")
+                                description="Minor address of the MCP4728 DAC unit. Use 0 unless you have changed the address manually")
     b_channel = Property.Select("Channel", [0, 1, 2, 3],
-                              description="DAC channel to use")
+                                description="DAC channel to use")
     c_volt_ref = Property.Select("Reference Voltage", ["Vdd", "Internal 2.048V", "Internal 4.096V"],
-                               description="Voltage Reference for DAC channel")
+                                 description="Voltage Reference for DAC channel")
     d_power_ctrl = Property.Select("Power Control", ["Zero DAC", "Actor"],
-                                 description="Power control method")
+                                   description="Power control method")
     e_power_actor = Property.Actor("Power On/Off Actor", description="Actor to use to control power")
-    timeout = Property.Number("Notification duration (ms)", True, 5000,
+    timeout = Property.Number("Notification duration (ms)", True, 1000,
                               description="0ms will disable notifications completely")
-    z_debug = Property.Select("Debug Messages", [0, 1], description="Display debug notifications")
-
+    z_debug = Property.Select("Debug Messages", [False, True], description="Display debug notifications")
 
     def init(self):
         address = int(self.a_address)
@@ -34,8 +33,8 @@ class MCP4728Actor(ActorBase):
         self.dac = mcp4728.MCP4728(address)
         if self.z_debug:
             cbpi.notify("Connected to MCP4728",
-                    "DAC Address {:d}: DAC Channel {:d}".format(address, channel),
-                    timeout=self.timeout)
+                        "DAC Address {:d}: DAC Channel {:d}".format(address, channel),
+                        timeout=self.timeout)
 
         if self.c_volt_ref == "Vdd":
             self.dac.set_vref(channel, 0)
@@ -88,7 +87,8 @@ class MCP4728Actor(ActorBase):
         self.state = 0
         if self.z_debug:
             value = self.dac.get_value(channel)
-            cbpi.notify("MCP4728 Current Value", "Channel {:d}: Value {:d}".format(channel, value), timeout=self.timeout)
+            cbpi.notify("MCP4728 Current Value", "Channel {:d}: Value {:d}".format(channel, value),
+                        timeout=self.timeout)
 
     def on(self, power=None):
         """Switch the actor on. Set the power to the given value or the current power setting."""
@@ -105,5 +105,5 @@ class MCP4728Actor(ActorBase):
 
         if self.z_debug:
             value = self.dac.get_value(channel)
-            cbpi.notify("MCP4728 Current Value", "Channel {:d}: Value {:d}".format(channel, value), timeout=self.timeout)
-
+            cbpi.notify("MCP4728 Current Value", "Channel {:d}: Value {:d}".format(channel, value),
+                        timeout=self.timeout)

--- a/mcp4728.py
+++ b/mcp4728.py
@@ -136,7 +136,7 @@ class MCP4728(object):
         self._bus.write_i2c_block_data(self._dev_address, first, [second, third])
 
     def _multi_write(self):
-        """MultiWrite input register values - All DAC ouput update. refer to DATASHEET 5.6.2
+        """MultiWrite input register values - All DAC output update. refer to DATASHEET 5.6.2
         DAC Input, Gain, Vref and PowerDown bits update
         No EEPROM update"""
         block = []
@@ -151,7 +151,7 @@ class MCP4728(object):
         self._bus.write_i2c_block_data(self._dev_address, block[0], block[1:])
 
     def _seq_write(self, start_channel=0):
-        """Sequential Write ALL input register values - All DAC ouput update. refer to DATASHEET 5.6.2
+        """Sequential Write ALL input register values - All DAC output update. refer to DATASHEET 5.6.2
         DAC Input, Gain, Vref and PowerDown bits update
         EEPROM is updated.
 


### PR DESCRIPTION
Fix race condition in mcp4728 when two channels were used in CBPi plugin.

Fix debug message settings